### PR TITLE
update homeassistant core from 2021.4.4 to 2021.4.6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ volumes:
 services:
   # https://hub.docker.com/r/homeassistant/home-assistant
   app:
-    image: homeassistant/home-assistant:2021.4.4
+    image: homeassistant/home-assistant:2021.4.6
     ports:
       - 80:8123
     volumes:


### PR DESCRIPTION
https://github.com/home-assistant/core/releases/tag/2021.4.6

Signed-off-by: Kyle Harding <kyle@balena.io>