### PR TITLE
Update homeassistant-core from 2021.4.6 to 2021.5.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ volumes:
 services:
   # https://hub.docker.com/r/homeassistant/home-assistant
   app:
-    image: homeassistant/home-assistant:2021.4.6
+    image: homeassistant/home-assistant:2021.5.1
     ports:
       - 80:8123
     volumes:


### PR DESCRIPTION
- https://www.home-assistant.io/blog/2021/05/05/release-20215/
- https://github.com/home-assistant/core/releases/tag/2021.5.1

Signed-off-by: Kyle Harding <kyle@balena.io>