### PR TITLE
Update homeassistant-core to 2021.5.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ volumes:
 services:
   # https://hub.docker.com/r/homeassistant/home-assistant
   app:
-    image: homeassistant/home-assistant:2021.5.1
+    image: homeassistant/home-assistant:2021.5.4
     ports:
       - 80:8123
     volumes:


### PR DESCRIPTION
https://github.com/home-assistant/core/releases/tag/2021.5.4

Signed-off-by: Kyle Harding <kyle@balena.io>