### PR TITLE
Update zigbee2mqtt to 1.24.0

### DIFF
--- a/zigbee2mqtt/Dockerfile
+++ b/zigbee2mqtt/Dockerfile
@@ -1,5 +1,8 @@
-FROM koenkk/zigbee2mqtt:1.23.0
+FROM koenkk/zigbee2mqtt:1.24.0
 
 # install default configuration for first boot
 # future changes must be made via the UI
 COPY configuration.yaml /app/
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD [ "/sbin/tini", "--", "node", "index.js"]


### PR DESCRIPTION
Also force the entrypoint and cmd to match upstream.

Otherwise the cmd seems to be replaced by the config copy command.

Signed-off-by: Kyle Harding <kyle@balena.io>