### PR TITLE
Remove /var/run tmpfs from duplicati

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,7 +83,6 @@ services:
       - "8200:8200/tcp"
     tmpfs:
       - /tmp
-      - /var/run/
     volumes:
       - duplicati:/config
       - config:/volumes/config


### PR DESCRIPTION
This mount prevents the service from starting due
to permission issues.

Change-type: patch