### PR TITLE
Only bind the internal Frigate port to loopback

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,7 +114,7 @@ services:
     privileged: true
     ports:
       - "8971:8971"
-      - "5000:5000" # Internal unauthenticated access. Expose carefully.
+      - "127.0.0.1:5000:5000" # Internal unauthenticated access. Expose carefully.
       - "8554:8554" # RTSP feeds
       - "8555:8555/tcp" # WebRTC over tcp
       - "8555:8555/udp" # WebRTC over udp


### PR DESCRIPTION
This allows Home Assistant running in host networking mode direct access, but externally TLS and auth is needed.