### PR TITLE
fix(zigbee2mqtt): update first boot config path

### DIFF
--- a/zigbee2mqtt/Dockerfile
+++ b/zigbee2mqtt/Dockerfile
@@ -2,4 +2,4 @@ FROM koenkk/zigbee2mqtt:1.42.0@sha256:732ae43d714610040bd049487b60af3b2dbcfdefb5
 
 # install default configuration for first boot
 # future changes must be made via the UI
-COPY configuration.yaml /app/
+COPY configuration.yaml /app/configuration.example.yaml


### PR DESCRIPTION
Hey Kyle, long time no see but I'm still relying on your projects <3

Seems like the path from where zigbee2mqtt gets the initial config was changed a while back, see
https://github.com/Koenkk/zigbee2mqtt/commit/68ec507e30bead5e9263c0fdc4c47e18c257d82f#diff-7cfc2aa3796f096105480a1a669658cfc12d2688b6300eef89d9ce94eef44e26R14

This fixed it for me.

Hope you are doing great!