### PR TITLE
Roll back code server to stable 4.96.4

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,3 +1,9 @@
 {
-  "extends": ["github>klutchell/renovate-config"]
+  "extends": ["github>klutchell/renovate-config"],
+  "packageRules": [
+    {
+      "matchPackagePatterns": ["codercom/code-server"],
+      "automerge": false
+    }
+  ]
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
 
   # https://hub.docker.com/r/codercom/code-server
   code-server:
-    image: codercom/code-server:4.97.2@sha256:6ff0e9cf5a553b3961ece200be75e21e8c887ed0ae28a7c28213722dccf74b0c
+    image: codercom/code-server:4.96.4
     command:
       - --port=9000
       - --auth=none


### PR DESCRIPTION
See: https://github.com/linuxserver/docker-code-server/issues/194