### PR TITLE
Remove Frigate service from compose stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,6 @@ The dashboard is running on port 6052.
 
 [Zigbee2MQTT](https://www.zigbee2mqtt.io/) supports various Zigbee adapters and the Web UI is on port 7000.
 
-#### frigate
-
-[Frigate](https://docs.frigate.video/) is a complete and local NVR designed for Home Assistant with AI object detection. The Web UI is on port 5000.
-
 #### wyze-bridge
 
 Docker container to expose a local RTMP, RTSP, and HLS or Low-Latency HLS stream for ALL your Wyze cameras including the outdoor and doorbell cams. No third-party or special firmware required.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,6 @@ services:
       - config:/config
       - zigbee2mqtt:/config/zigbee2mqtt
       - esphome:/config/esphome
-      - frigate-config:/config/frigate
     user: root
 
   # https://hub.docker.com/_/influxdb
@@ -113,34 +112,9 @@ services:
       - influxdb-config:/volumes/influxdb-config
       - grafana:/volumes/grafana
       - zigbee2mqtt:/volumes/zigbee2mqtt
-      - frigate-media:/volumes/frigate-media
       - tailscale:/volumes/tailscale
       - netdatalib:/volumes/netdatalib
       - esphome:/volumes/esphome
-
-  # https://docs.frigate.video/frigate/installation
-  frigate:
-    image: ghcr.io/blakeblackshear/frigate:0.15.2@sha256:44745918b0124253890b389e41ed9e24553bd156ab3f9e2b06723c0dfed2af8c
-    privileged: true
-    ports:
-      - "8971:8971"
-      - "127.0.0.1:5000:5000" # Internal unauthenticated access. Expose carefully.
-      - "8554:8554" # RTSP feeds
-      - "8555:8555/tcp" # WebRTC over tcp
-      - "8555:8555/udp" # WebRTC over udp
-    volumes:
-      - frigate-config:/config
-      - frigate-media:/media/frigate
-    tmpfs:
-      - /tmp/cache
-    shm_size: 2048M
-    environment:
-      FRIGATE_RTSP_PASSWORD: "balena"
-      CONFIG_FILE: "/config/config.yml"
-    labels:
-      io.balena.features.kernel-modules: 1
-    devices:
-      - /dev/dri:/dev/dri
 
   # https://github.com/home-assistant-libs/python-matter-server/blob/main/docs/docker.md
   matter-server:
@@ -240,8 +214,6 @@ volumes:
   mqtt: {}
   zigbee2mqtt: {}
   duplicati: {}
-  frigate-config: {}
-  frigate-media: {}
   wyze-tokens: {}
   tailscale: {}
   netdatalib: {}


### PR DESCRIPTION
A service like this runs better on dedicated hardware with a stack like https://github.com/klutchell/balena-frigate