### PR TITLE
Remove grafana and influxdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,46 +56,6 @@ Docker container to expose a local RTMP, RTSP, and HLS or Low-Latency HLS stream
 
 <https://github.com/mrlt8/docker-wyze-bridge>
 
-#### influxdb & grafana
-
-You may optionally duplicate the Home Assistant sensor data to an
-influx database and generate graphs in the Grafana dashboard.
-
-Start by opening a terminal to the `influxdb` service and creating
-a database and user credentials.
-
-```bash
-influx
-
-create database homeassistant
-show databases
-
-create user homeassistant with password 'homeassistant'
-show users
-
-grant all on homeassistant to homeassistant
-exit
-```
-
-Then the following block to your Home Assistant configuration.yml to
-transfer all state changes to an external InfluxDB database
-
-```yaml
-# https://www.home-assistant.io/integrations/influxdb/
-influxdb:
-  host: influxdb
-  port: 8086
-  database: homeassistant
-  username: !secret influxdb_user
-  password: !secret influxdb_password
-  max_retries: 3
-  include:
-    domains:
-      - sensor
-```
-
-The Grafana dashboard should be available at <http://homeassistant.local:3000> and the default credentials are `admin/admin`.
-
 #### hostname
 
 An utility block to set the hostname of devices running balenaOS.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,31 +58,6 @@ services:
       - esphome:/config/esphome
     user: root
 
-  # https://hub.docker.com/_/influxdb
-  # https://www.home-assistant.io/integrations/influxdb/
-  influxdb:
-    image: influxdb:2.7.12-alpine@sha256:d948cd7aa274696d76ccc3f7ef732180d9f9a4229aace3cf68ae008693665137
-    environment:
-      DOCKER_INFLUXDB_INIT_MODE: setup
-      DOCKER_INFLUXDB_INIT_USERNAME: homeassistant
-      DOCKER_INFLUXDB_INIT_PASSWORD: homeassistant # changeme via fleet/device env vars
-      DOCKER_INFLUXDB_INIT_ORG: homeassistant
-      DOCKER_INFLUXDB_INIT_BUCKET: homeassistant
-      DOCKER_INFLUXDB_INIT_RETENTION: 90d
-    volumes:
-      - influxdb-data:/var/lib/influxdb2
-      - influxdb-config:/etc/influxdb2
-    ports:
-      - 127.0.0.1:8086:8086
-
-  # https://hub.docker.com/r/grafana/grafana
-  grafana:
-    image: grafana/grafana:12.0.2@sha256:b5b59bfc7561634c2d7b136c4543d702ebcc94a3da477f21ff26f89ffd4214fa
-    volumes:
-      - grafana:/var/lib/grafana
-    ports:
-      - 3000:3000/tcp
-
   # https://github.com/balenablocks/hostname
   hostname:
     build: hostname
@@ -184,9 +159,6 @@ services:
 
 volumes:
   config: {}
-  influxdb-data: {}
-  influxdb-config: {}
-  grafana: {}
   mqtt: {}
   zigbee2mqtt: {}
   wyze-tokens: {}


### PR DESCRIPTION
Home Assistant has improved it's history retention and queries to the point that these additional services are no longer required.